### PR TITLE
Bitbucket: gracefully ignore unrecognized payloads

### DIFF
--- a/src/routes/bitbucket.js
+++ b/src/routes/bitbucket.js
@@ -13,7 +13,6 @@ module.exports.create = create
 Bitbucket.prototype.post = function (req, res) {
   var authorizedIps = config.security.authorizedIps
   var bitbucketIps = config.security.bitbucketIps
-  var commits = req.body.push.changes
   var ipv4 = req.ip.replace('::ffff:', '')
 
   if (!(authorizedIps.indexOf(ipv4) >= 0 || bitbucketIps.indexOf(ipv4) >= 0)) {
@@ -23,6 +22,13 @@ Bitbucket.prototype.post = function (req, res) {
     return
   }
 
+  if (!req.body.push) {
+    res.writeHead(204)
+    res.end()
+    return
+  }
+
+  var commits = req.body.push.changes
   if (commits.length <= 0) {
     res.writeHead(204)
     res.end()

--- a/test/routes/bitbucket.test.js
+++ b/test/routes/bitbucket.test.js
@@ -16,6 +16,38 @@ function mockReq () {
   }
 }
 
+test('The Bitbucket endpoint with non-push payload should return 204', (assert) => {
+  var bitbucket = bitbucketController.create({
+    security: {
+      authorizedIps: ['1.2.3.4'],
+      bitbucketIps: []
+    },
+    repository: {
+      branch: 'master'
+    },
+    action: {
+      exec: {
+        bitbucket: '../bitbucket.sh'
+      }
+    }
+  })
+
+  var req = { ip: '::ffff:1.2.3.4', body: {} }
+  var res = {}
+  var code
+
+  res.writeHead = function (statusCode) {
+    code = statusCode
+  }
+
+  res.end = function () {
+    assert.equal(code, 204)
+    assert.end()
+  }
+
+  bitbucket.post(req, res)
+})
+
 test('The Bitbucket endpoint with authorized IP should return 200', (assert) => {
   var bitbucket = bitbucketController.create({
     security: {


### PR DESCRIPTION
Related to https://github.com/A21z/node-cd/issues/14
If receiving a payload from an unsupported webhook
(such as an empty payload, or payload for non-push operations such as
comments, issues, forks, etc.) the webhook is ignored and
returns an HTTP 204 code.
